### PR TITLE
BugFix

### DIFF
--- a/model/saturn_model.py
+++ b/model/saturn_model.py
@@ -212,7 +212,7 @@ class SATURNPretrainModel(torch.nn.Module):
         loss = nn.MSELoss(reduction="sum")
         similarity = torch.nn.CosineSimilarity()
         
-        idx1 = torch.randint(low=0, high=embeddings.shape[1], size=(x1.shape[0],))      
+        idx1 = torch.randint(low=0, high=x1.shape[0], size=(x1.shape[0],))
         x2 = x1[idx1, :]
         target = similarity(embeddings, embeddings[idx1, :])
         


### PR DESCRIPTION
Hi,

I think idx1 is supposed to form a random pairing for x1 (that is x2).
So, you should choose from 0 to x1.shape[0] not from 0 to embeddings.shape[1] that is irrelevant to the x1.

This may even raise out-of-bound errors is some edge cases.